### PR TITLE
Allow addings stubs outside of "tests" directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,7 @@ jobs:
       run: composer update --${{ matrix.dependency-version }} --no-interaction --prefer-dist
 
     - name: Coding Style Checks
-      run: |
-           vendor/bin/rector process src --dry-run
-           vendor/bin/php-cs-fixer fix -v --dry-run
+      run: vendor/bin/php-cs-fixer fix -v --dry-run
 
     - name: Type Checks
       run: vendor/bin/phpstan analyse --ansi

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -14,8 +14,8 @@ final class Plugin implements HandlesArguments
     private const INIT_OPTION = 'init';
 
     private const STUBS = [
-        'Pest.php'    => 'Pest.php',
-        'Helpers.php' => 'Helpers.php',
+        'Pest.php'    => 'tests/Pest.php',
+        'Helpers.php' => 'tests/Helpers.php',
     ];
 
     /** @var OutputInterface */
@@ -60,11 +60,11 @@ final class Plugin implements HandlesArguments
 
         foreach (self::STUBS as $from => $to) {
             $fromPath = __DIR__ . "/../stubs/$from";
-            $toPath   = "$testsBaseDir/$to";
+            $toPath   = "{$this->testSuite->rootPath}/$to";
 
             if (file_exists($toPath)) {
                 $this->output->writeln(sprintf(
-                    "<fg=yellow>[WARNING] File `%s` already exists, skipped</>",
+                    "<fg=yellow>[INFO] File `%s` already exists, skipped</>",
                     $to
                 );
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -13,6 +13,7 @@ final class Plugin implements HandlesArguments
     private const INIT_OPTION = 'init';
 
     private const STUBS = [
+        'phpunit.xml' => 'phpunit.xml',
         'Pest.php'    => 'tests/Pest.php',
         'Helpers.php' => 'tests/Helpers.php',
     ];

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -82,11 +82,11 @@ final class Plugin implements HandlesArguments
             }
 
             $this->output->writeln(sprintf(
-                '<fg=black;bg=green>[OK] Created `%s` file</>',
+                '<fg=green>[OK] Created `%s` file</>',
                 $to
             ));
         }
 
-        $this->output->writeln('<fg=black;bg=green>[OK] Pest initialised!</>');
+        $this->output->writeln('<fg=green>[OK] Pest initialised!</>');
     }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Pest\Init;
 
 use Pest\Contracts\Plugins\HandlesArguments;
-use Pest\Exceptions\ShouldNotHappen;
 use Pest\TestSuite;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -48,7 +47,7 @@ final class Plugin implements HandlesArguments
         if (!is_dir($testsBaseDir)) {
             if (!mkdir($testsBaseDir) && !is_dir($testsBaseDir)) {
                 $this->output->writeln(sprintf(
-                    "<fg=white;bg=red>[ERROR] Directory `%s` was not created</>",
+                    '<fg=white;bg=red>[ERROR] Directory `%s` was not created</>',
                     $testsBaseDir
                 ));
 
@@ -64,16 +63,16 @@ final class Plugin implements HandlesArguments
 
             if (file_exists($toPath)) {
                 $this->output->writeln(sprintf(
-                    "<fg=yellow>[INFO] File `%s` already exists, skipped</>",
+                    '<fg=yellow>[INFO] File `%s` already exists, skipped</>',
                     $to
-                );
+                ));
 
                 continue;
             }
 
             if (!copy($fromPath, $toPath)) {
                 $this->output->writeln(sprintf(
-                    "<fg=white;bg=red>[WARNING] Failed to copy stub `%s` to `%s`</>",
+                    '<fg=white;bg=red>[WARNING] Failed to copy stub `%s` to `%s`</>',
                     $from,
                     $toPath
                 ));
@@ -82,7 +81,7 @@ final class Plugin implements HandlesArguments
             }
 
             $this->output->writeln(sprintf(
-                "<fg=black;bg=green>[OK] Created `%s` file</>",
+                '<fg=black;bg=green>[OK] Created `%s` file</>',
                 $to
             ));
         }

--- a/stubs/phpunit.xml
+++ b/stubs/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory suffix="Test.php">./tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./app</directory>
+            <directory suffix=".php">./src</directory>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
This just updates the paths so that we'd be able to add files such as `phpunit.xml.dist` which sits outside of the tests directory. 👍