### PR TITLE
Label wording update

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -75,7 +75,7 @@ final class Plugin implements HandlesArguments
             }
 
             $this->output->writeln(
-                '  <fg=black;bg=green;options=bold> OK </> Created `tests` directory.</>',
+                '  <fg=black;bg=green;options=bold> DONE </> Created `tests` directory.</>',
             );
         }
 
@@ -103,13 +103,13 @@ final class Plugin implements HandlesArguments
             }
 
             $this->output->writeln(sprintf(
-                '  <fg=black;bg=green;options=bold> OK </> Created `%s` file.</>',
+                '  <fg=black;bg=green;options=bold> DONE </> Created `%s` file.</>',
                 $to
             ));
         }
 
         $this->output->writeln(
-            "\n  <fg=black;bg=green;options=bold> OK </> Pest initialised.</>",
+            "\n  <fg=black;bg=green;options=bold> DONE </> Pest initialised.</>",
         );
     }
 }


### PR DESCRIPTION
Replaced ` OK ` labels by ` DONE `:
Now all labels have the same length and their text is always vertically aligned.

#OCD


<img width="457" alt="Capture d’écran 2020-06-14 à 17 43 05" src="https://user-images.githubusercontent.com/19224681/84597930-65bd7100-ae67-11ea-81ed-c0f4ab57f2c7.png">

<img width="451" alt="Capture d’écran 2020-06-14 à 17 45 51" src="https://user-images.githubusercontent.com/19224681/84597929-648c4400-ae67-11ea-980d-811a8ffce65b.png">