### PR TITLE
Make usage of the `phpunit.xml.dist` file

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -23,7 +23,7 @@ final class Plugin implements HandlesArguments
      * The files that will be created.
      */
     private const STUBS = [
-        'phpunit.xml'     => 'phpunit.xml',
+        'phpunit.xml'     => 'phpunit.xml.dist',
         'Pest.php'        => 'tests/Pest.php',
         'ExampleTest.php' => 'tests/ExampleTest.php',
     ];

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -23,7 +23,7 @@ final class Plugin implements HandlesArguments
      * The files that will be created.
      */
     private const STUBS = [
-        'phpunit.xml'     => 'phpunit.xml.dist',
+        'phpunit.xml'     => 'phpunit.xml',
         'Pest.php'        => 'tests/Pest.php',
         'ExampleTest.php' => 'tests/ExampleTest.php',
     ];
@@ -87,6 +87,15 @@ final class Plugin implements HandlesArguments
                 $this->output->writeln(sprintf(
                     '  <fg=black;bg=yellow;options=bold> INFO </> File `%s` already exists, skipped.</>',
                     $to
+                ));
+
+                continue;
+            }
+
+            if ($from === 'phpunit.xml' && file_exists($toPath . '.dist') ) {
+                $this->output->writeln(sprintf(
+                    '  <fg=black;bg=yellow;options=bold> INFO </> File `%s` already exists, skipped.</>',
+                    $to . '.dist'
                 ));
 
                 continue;


### PR DESCRIPTION
While [testing pest](https://github.com/sulu/sulu-demo/pull/93) in combination with @sulu I did see the that init plugin generates a `phpunit.xml`. The `phpunit.xml` is in the symfony world in the `.gitignore` (done by symfony/flex here: https://github.com/symfony/recipes/blob/be987091a077badc8cbc40cd634d6f4448a353f1/phpunit/phpunit/4.7/manifest.json#L8) and so not commited only the `phpunit.xml.dist` is the commitet file there. I think it would be great if the pest init command does generate the `phpunit.xml.dist` file instead of `phpunit.xml`.